### PR TITLE
Fix CLARA_HOME if statement in bash

### DIFF
--- a/docker/clas12/environment.sh
+++ b/docker/clas12/environment.sh
@@ -32,7 +32,7 @@ export CLAS12_INC=$JLAB_SOFTWARE/clas12/inc
 export CLAS12_BIN=$JLAB_SOFTWARE/clas12/bin
 
 export CLARA_HOME=$JLAB_ROOT/$JLAB_VERSION/claraHome
-if  [ -d $CLARA_HOME)
+if  [ -d $CLARA_HOME ];
 then
 	export COATJAVA=$CLARA_HOME/plugins/clas12
 	export JAVA_HOME=$CLARA_HOME/jre/$JRE


### PR DESCRIPTION
Fixs:
```
bash: /etc/profile.d/environment.sh: line 35: syntax error near unexpected token `)'
bash: /etc/profile.d/environment.sh: line 35: `if  [ -d $CLARA_HOME)'
```

When starting bash.